### PR TITLE
Hide menu bar

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -61,6 +61,13 @@ function createMainWindow() {
 
   const url = `file://${path.join(__dirname, 'renderer', 'index.html')}`
 
+  /*/
+  / /Hide menu bar: default
+  / /Show menu bar: press 'alt'
+  /*/
+  win.setAutoHideMenuBar(true)
+  win.setMenuBarVisibility(false)
+  
   win.loadURL(url)
 
   win.on('close', e => {


### PR DESCRIPTION
Hi I think it would be better when you press alt, the menu bar is displayed and it is hidden by default?

Hide menu bar: default
Show menu bar: press 'alt'

Accepte this pull request.