### PR TITLE
feat: Users can now toggle the header on and off.

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -9,6 +9,7 @@ module.exports = new Config({
     shortcut: {
       toggleApp: null
     },
+    showHeader: true,
     mode: 'dark'
   }
 })

--- a/app/index.js
+++ b/app/index.js
@@ -60,7 +60,8 @@ function createMainWindow() {
     },
     webPreferences: {
       nodeIntegration: true,
-      webviewTag: true
+      webviewTag: true,
+      // preload: "renderer/preload-index.js"
     }
   })
 

--- a/app/menu.js
+++ b/app/menu.js
@@ -3,7 +3,8 @@ const {
   shell,
   globalShortcut,
   BrowserWindow,
-  dialog
+  dialog,
+  ipcMain: ipc
 } = require('electron')
 const axios = require('axios')
 const semverCompare = require('semver-compare')
@@ -46,6 +47,15 @@ function createMenu(opts) {
           label: 'Custom JS',
           click() {
             shell.openItem(configDir('custom.js'))
+          }
+        },
+        {
+          label: 'Toggle Header Bar',
+          click() {
+            const [win] = BrowserWindow.getAllWindows();
+            const showHeader = !config.get("showHeader");
+            win.webContents.send("toggle-header", showHeader);
+            config.set("showHeader", showHeader);
           }
         },
         {

--- a/app/renderer/main.js
+++ b/app/renderer/main.js
@@ -23,10 +23,16 @@ function ensureCustomFiles() {
   }
 }
 
+ipc.on('toggle-header', (event, state) => {
+  const headerBar = document.getElementsByTagName("header")[0];
+  headerBar.style.display = state ? "" : "none";
+});
+
 function createHeader() {
   const header = document.createElement('header')
   header.className = 'header'
   header.innerHTML = '<h1 id="title" class="app-title">Loading DevDocs...</h1>'
+	header.style.display = config.get("showHeader") ? "" : "none";
   header.addEventListener('dblclick', () => {
     win.maximize()
   })


### PR DESCRIPTION
I'm too tired from work right now, but you should really consider
turning node-integration off. I understand the nuiscance of it, but
it would be added security for users. I'm not a pentester, but I know
hardening is good in most projects.